### PR TITLE
Check sars1_195 probs only to 6 places

### DIFF
--- a/hip/tests/test_main.py
+++ b/hip/tests/test_main.py
@@ -73,7 +73,7 @@ class TestMain(unittest.TestCase):
         # verify that probability distribution is as expected
         expected = np.load("./hip/tests/fixture/sars1_195_final_scores_binds_prob.npy")
         actual = probs
-        self.assertAlmostEqual(0, norm(expected - actual))
+        self.assertAlmostEqual(0, norm(expected - actual), places=6)
 
     def test_model_save_locations(self):
         # verify that model is saved with expected file names in expected directory


### PR DESCRIPTION
We have seen `TestMain.test_sars1_195` fail with a very small error.

  AssertionError: 0 != 2.18198395037895e-07 within 7 places (2.18198395037895e-07 difference)

It is not necessary that the difference be this small in norm. It should be sufficient to test to 6 decimal places.